### PR TITLE
feat: add Last.fm endpoint integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Backend API service for personal portfolio website that provides realtime data a
 - **Realtime Integration**
   - Discord presence status
   - Spotify current track
+  - Last.fm current track
   - Steam gaming activity
   - GitHub pinned repositories
   - Anonymous messaging system
@@ -55,6 +56,24 @@ Returns currently playing track info from Spotify.
   "albumImageUrl": "https://...",
   "songUrl": "https://..."
 }
+```
+
+### Last.fm Current Track
+```
+GET /api/lastfm
+```
+Returns currently playing track info from lastfm.
+
+**Response Example:**
+```json
+{
+  "name": "Track Name",
+  "artist": "Artist Name",
+  "album": "Album Name",
+  "albumImageUrl": "https://...",
+  "url": "https://...",
+  "isNowPlaying": true
+},
 ```
 
 ### Steam Activity
@@ -148,6 +167,10 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_key
 SPOTIFY_CLIENT_ID=your_spotify_client_id
 SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
 SPOTIFY_REFRESH_TOKEN=your_spotify_refresh_token
+
+# Last.fm
+LASTFM_USERNAME=your_lastfm_username
+LASTFM_API_KEY=your_lastfm_apikey
 
 # Steam
 STEAM_API_KEY=your_steam_api_key

--- a/app/api/lastfm/route.ts
+++ b/app/api/lastfm/route.ts
@@ -1,0 +1,61 @@
+import { getRecentTracks } from '../../lib/lastfm';
+import type { LastFmTrack } from '../../types';
+
+export const runtime = 'edge';
+
+export async function GET() {
+  try {
+    const data = await getRecentTracks();
+
+    if (!data) {
+      return new Response(
+        JSON.stringify({ tracks: [] }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    }
+
+    const tracks: LastFmTrack[] = data.recenttracks.track.map((track: {
+      name: string;
+      artist: { '#text': string };
+      album: { '#text': string };
+      image: { size: string; '#text': string }[];
+      url: string;
+      '@attr'?: { nowplaying: string };
+      date?: { uts: string };
+    }) => ({
+      name: track.name,
+      artist: track.artist['#text'],
+      album: track.album['#text'],
+      albumImageUrl: track.image.find(img => img.size === 'large')?.['#text'] || '',
+      url: decodeURIComponent(track.url),
+      isNowPlaying: track['@attr']?.nowplaying === 'true',
+      timestamp: track.date?.uts,
+    }));
+
+    return new Response(
+      JSON.stringify({ tracks }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  } catch (error) {
+    console.error('Error fetching Last.fm data:', error);
+    return new Response(
+      JSON.stringify({ tracks: [] }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  }
+}

--- a/app/lib/lastfm.ts
+++ b/app/lib/lastfm.ts
@@ -1,0 +1,19 @@
+const LASTFM_API_KEY = process.env.LASTFM_API_KEY;
+const LASTFM_USERNAME = process.env.LASTFM_USERNAME;
+
+export async function getRecentTracks() {
+  const url = `https://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=${LASTFM_USERNAME}&api_key=${LASTFM_API_KEY}&format=json`;
+
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch Last.fm data');
+    }
+    
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching Last.fm data:', error);
+    return null;
+  }
+}

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -45,3 +45,13 @@ export interface SpotifyArtist {
       };
     };
   }
+
+  export interface LastFmTrack {
+    name: string; 
+    artist: string; 
+    album: string; 
+    albumImageUrl: string; 
+    url: string;
+    isNowPlaying: boolean;
+    timestamp?: string; 
+  }


### PR DESCRIPTION
- Implemented a new endpoint for Last.fm data retrieval.
- Supports fetching data such as current track.
- Includes error handling for API requests.
- Updated API documentation to include the new endpoint.

example:

```json
{
   "name": "Don't Fade Away",
   "artist": "Beach Fossils",
   "album": "Bunny",
   "albumImageUrl": "https://lastfm.freetls.fastly.net/i/u/174s/21c3f56979daf621a4dc900c667a1ebf.png",
   "url": "https://www.last.fm/music/Beach+Fossils/_/Don't+Fade+Away",
   "isNowPlaying": true
}
```