### PR TITLE
feat: add Stats.fm endpoint integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,32 @@ Returns currently playing track info from lastfm.
 },
 ```
 
+### Stats.fm Current Track
+```
+GET /api/statsfm
+```
+Returns currently playing track info from statsfm.
+
+**Response Example:**
+```json
+{
+  "track": {
+    "name": "Track Name",
+    "artists": "Artist Name",
+    "album": "Album Name",
+    "albumImageUrl": "https://...",
+    "url": "https://...",
+    "isPlaying": true,
+    "progressMs": 00000,
+    "platform": "SPOTIFY",
+    "spotifyPopularity": 00,
+    "explicit": false,
+    "durationMs": 11111,
+    "date": "yyyy-mm-00T00:00:00.000Z"
+  }
+}
+```
+
 ### Steam Activity
 ```
 GET /api/steam
@@ -171,6 +197,9 @@ SPOTIFY_REFRESH_TOKEN=your_spotify_refresh_token
 # Last.fm
 LASTFM_USERNAME=your_lastfm_username
 LASTFM_API_KEY=your_lastfm_apikey
+
+# Stats.fm
+STATSFM_USERNAME=your_statsfm_username
 
 # Steam
 STEAM_API_KEY=your_steam_api_key

--- a/app/api/statsfm/route.ts
+++ b/app/api/statsfm/route.ts
@@ -1,0 +1,31 @@
+import { getCurrentTrack } from '../../lib/statsfm';
+import type { StatsFmTrack } from '../../types';
+
+export const runtime = 'edge';
+
+export async function GET() {
+  try {
+    const track: StatsFmTrack | null = await getCurrentTrack();
+
+    return new Response(
+      JSON.stringify({ track }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  } catch (error) {
+    console.error('Error fetching Stats.fm data:', error);
+    return new Response(
+      JSON.stringify({ track: null }),
+      {
+        status: 500,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  }
+}

--- a/app/lib/statsfm.ts
+++ b/app/lib/statsfm.ts
@@ -1,0 +1,39 @@
+const STATSFM_USERNAME = process.env.STATSFM_USERNAME;
+
+export async function getCurrentTrack() {
+  const url = `https://api.stats.fm/api/v1/users/${STATSFM_USERNAME}/streams/current`;
+
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch Stats.fm data: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+
+    if (!data.item || !data.item.track) {
+      return null;
+    }
+
+    const track = data.item.track;
+
+    return {
+      name: track.name || 'Unknown',
+      artists: track.artists.map((artist: { name: string }) => artist.name).join(', ') || 'Unknown',
+      album: track.albums[0]?.name || 'Unknown',
+      albumImageUrl: track.albums[0]?.image || '',
+      url: `https://stats.fm/track/${track.id}`,
+      isPlaying: data.item.isPlaying,
+      progressMs: data.item.progressMs,
+      platform: data.item.platform,
+      spotifyPopularity: track.spotifyPopularity || 0,
+      explicit: track.explicit || false,
+      durationMs: track.durationMs || 0,
+      date: data.item.date || null,
+    };
+  } catch (error) {
+    console.error('Error fetching Stats.fm data:', error);
+    return null;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,12 @@ export default function Home() {
         
         <h3>GET /api/spotify</h3>
         <p>Returns current playing track from Spotify</p>
+
+        <h3>GET /api/lastfm</h3>
+        <p>Returns current playing track from lastfm</p>
+
+        <h3>GET /api/statsfm</h3>
+        <p>Returns current playing track from Stats.fm</p>
         
         <h3>GET /api/steam</h3>
         <p>Returns current or recent game activity from Steam</p>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -55,3 +55,18 @@ export interface SpotifyArtist {
     isNowPlaying: boolean;
     timestamp?: string; 
   }
+
+  export interface StatsFmTrack {
+    name: string;
+    artists: string;
+    album: string;
+    albumImageUrl: string;
+    url: string;
+    isPlaying: boolean;
+    progressMs: number;
+    platform: string;
+    spotifyPopularity: number;
+    explicit: boolean;
+    durationMs: number;
+    date: string | null;
+  }


### PR DESCRIPTION
- Implemented a new endpoint for Stats.fm data retrieval.
- Supports fetching data such as current track (name, artist, album, platform...).
- Includes error handling for API requests.
- Updated API documentation to include the new endpoint.

example:

```json
{
  "track": {
    "name": "I Shimmer",
    "artists": "Jadu Heart",
    "album": "Derealised",
    "albumImageUrl": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/4a/a6/a3/4aa6a323-f41c-e625-d08b-2a34bc34f33b/cover.jpg/768x768bb.jpg",
    "url": "https://stats.fm/track/52852571",
    "isPlaying": true,
    "progressMs": 13615,
    "platform": "SPOTIFY",
    "spotifyPopularity": 26,
    "explicit": false,
    "durationMs": 265278,
    "date": "2025-01-21T01:17:06.081Z"
  }
}
```